### PR TITLE
Added configMap for OIDC

### DIFF
--- a/charts/owncloud/templates/configMap.yaml
+++ b/charts/owncloud/templates/configMap.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.owncloud.oidc.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: owncloud-config
+  namespace: default
+data:
+  docker.oidc.config.php: |
+    <?php
+    $CONFIG = [
+            "openid-connect" => [
+                    "provider-url" => $_ENV["OWNCLOUD_OIDC_PROVIDER_URL"],
+                    "post_logout_redirect_uri" => $_ENV["OWNCLOUD_OIDC_POST_LOGOUT_REDIRECT_URL"],
+                    "client-id" => $_ENV["OWNCLOUD_OIDC_CLIENT_ID"],
+                    "client-secret" => $_ENV["OWNCLOUD_OIDC_CLIENT_SECRET"],
+                    "loginButtonName" => "Azure AD",
+                    "autoRedirectOnLoginPage" => false,
+                    "scopes" => [
+                            "openid",
+                            $_ENV["OWNCLOUD_OIDC_SCOPES_API"],
+                            "profile", "email", "offline_access",
+                    ],
+                    "mode" => "email",
+                    "search-attribute" => "unique_name",
+                    "use-access-token-payload-for-user-info" => true,
+                    'auto-provision' => [
+                            'enabled' => true,
+                            'email-claim' => 'email',
+                            'display-name-claim' => 'name',
+                    ],
+            ],
+    ];
+{{- end }}

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,6 +30,14 @@ spec:
       serviceAccountName: {{ include "owncloud.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: "init-{{ .Chart.Name }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume_apps }} {{ .Values.owncloud.volume_config }} {{ .Values.owncloud.volume_files }}; chown -R www-data:www-data {{ .Values.owncloud.volume_root }}"]
+          volumeMounts:
+          - name: owncloud-data
+            mountPath: {{ .Values.owncloud.volume_root }}
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -40,6 +47,18 @@ spec:
           env:
           - name: OWNCLOUD_DOMAIN
             value: {{ .Values.owncloudDomain | quote }}
+          - name: OWNCLOUD_SKIP_CHMOD
+            value: "true"
+          - name: OWNCLOUD_SKIP_CHOWN
+            value: "true"
+          - name: OWNCLOUD_VOLUME_APPS
+            value: {{ .Values.owncloud.volume_apps | quote }}
+          - name: OWNCLOUD_VOLUME_CONFIG
+            value: {{ .Values.owncloud.volume_config | quote }}
+          - name: OWNCLOUD_VOLUME_FILES
+            value: {{ .Values.owncloud.volume_files | quote }}
+          - name: OWNCLOUD_VOLUME_ROOT
+            value: {{ .Values.owncloud.volume_root | quote }}
           - name: OWNCLOUD_ADMIN_USERNAME
             value: {{ .Values.owncloud.username | quote }}
           - name: OWNCLOUD_ADMIN_PASSWORD
@@ -81,6 +100,18 @@ spec:
           - name: OWNCLOUD_REDIS_HOST
             value: {{ .Values.redis.host | quote }}
           {{- end }}
+          {{- if .Values.owncloud.oidc.enabled }}
+          - name: OWNCLOUD_OIDC_PROVIDER_URL
+            value: {{ .Values.owncloud.oidc.providerurl | quote }}
+          - name: OWNCLOUD_OIDC_POST_LOGOUT_REDIRECT_URL
+            value: {{ .Values.owncloud.oidc.logouturl | quote }}
+          - name: OWNCLOUD_OIDC_CLIENT_ID
+            value: {{ .Values.owncloud.oidc.clientid | quote }}
+          - name: OWNCLOUD_OIDC_CLIENT_SECRET
+            value: {{ .Values.owncloud.oidc.clientsecret | quote }}
+          - name: OWNCLOUD_OIDC_SCOPES_API
+            value: {{ .Values.owncloud.oidc.scopesapi | quote }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080
@@ -109,7 +140,12 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - name: owncloud-data
-            mountPath: /mnt/data
+            mountPath: {{ .Values.owncloud.volume_root }}
+          {{- if .Values.owncloud.oidc.enabled }}
+          - name: config-volume
+            mountPath: {{ .Values.owncloud.volume_config }}/docker.oidc.config.php
+            subPath: docker.oidc.config.php
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -126,3 +162,8 @@ spec:
         - name: owncloud-data
           persistentVolumeClaim:
             claimName: {{ include "owncloud.fullname" . }}
+        {{- if .Values.owncloud.oidc.enabled }}
+        - name: config-volume
+          configMap:
+            name: owncloud-config
+        {{- end }}

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -5,6 +5,17 @@ owncloud:
   domain: owncloud.chart.example
   username: owncloud
   password: owncloud
+  volume_apps: /mnt/data/apps
+  volume_config: /mnt/data/config
+  volume_files: /mnt/data/files
+  volume_root: /mnt/data
+  oidc:
+    enabled: true
+    providerurl: test
+    logouturl: test
+    clientid: test
+    clientsecret: test
+    scopesapi: test
 
 mariadb:
   enabled: false
@@ -67,7 +78,7 @@ ingress:
       servicePort: 80
   tls:
     - hosts:
-        - "owncloud.chart.example"
+      - "owncloud.chart.example"
       secretName: owncloud
 
 resources:


### PR DESCRIPTION
This PR adds a configMap for OIDC configuration. Therefor it also introduces an `initContainer` as the permissions cannot be set with the configMap readonly overlay on top of the persistent `volume_root` volume. The change also adds helm config values for OWNCLOUD_VOLUME_ROOT, OWNCLOUD_VOLUME_FILES, OWNCLOUD_VOLUME_CONFIG and OWNCLOUD_VOLUME_APPS