### PR TITLE
feat: allow service annotations

### DIFF
--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -264,6 +264,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | resources | object | `{}` | Resources to apply to all services. |
 | securityContext | object | `{"readOnlyRootFilesystem":false}` | Security settings for the Container. |
 | securityContext.readOnlyRootFilesystem | bool | `false` | Mounts the container's root filesystem as read-only. Currently only `false` is supported by ownCloud 10. |
+| service.annotations | object | `{}` | Service annotations. |
 | service.port | int | `8080` |  |
 | service.type | string | `"LoadBalancer"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |

--- a/charts/owncloud/templates/service.yaml
+++ b/charts/owncloud/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: owncloud
   labels:
     {{- include "owncloud.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -434,6 +434,9 @@ securityContext:
 service:
   type: LoadBalancer
   port: 8080
+  # -- Service annotations.
+  annotations: {}
+
 
 ingress:
   # -- Enables the Ingress.


### PR DESCRIPTION
In some conditions services need to be annotated, e.g. for session affinity of the ingress. This PR adds this configuration possibility.