### PR TITLE
feat: add annotations to pvc

### DIFF
--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -255,6 +255,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
 | persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
+| persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC |
 | persistence.owncloud.nfs | object | `{}` |  |
 | persistence.owncloud.size | string | `"20Gi"` |  |
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -255,7 +255,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
 | persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
-| persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC |
+| persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC. |
 | persistence.owncloud.nfs | object | `{}` |  |
 | persistence.owncloud.size | string | `"20Gi"` |  |
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |

--- a/charts/owncloud/templates/pvc.yaml
+++ b/charts/owncloud/templates/pvc.yaml
@@ -19,6 +19,10 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "owncloud.fullname" . }}
+  {{- with .Values.persistence.owncloud.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   accessModes:
     {{- toYaml .Values.persistence.owncloud.accessMode | nindent 4 }}

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -409,6 +409,9 @@ persistence:
     nfs: {}
     # -- owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner.
     storageClassName: ""
+    # -- Set annotations on the owncloud PVC
+    annotations: 
+      "helm.sh/resource-policy": keep
 
 # -- Number of replicas for each scalable service. Has no effect when `autoscaling.enabled` is set to `true`.
 replicas: 1

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -409,7 +409,7 @@ persistence:
     nfs: {}
     # -- owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner.
     storageClassName: ""
-    # -- Set annotations on the owncloud PVC
+    # -- Set annotations on the owncloud PVC.
     annotations: 
       "helm.sh/resource-policy": keep
 


### PR DESCRIPTION
This PR adds annotation configuration support to the PVC. It also sets a default so that helm doesn't delete the volume.