### PR TITLE
feat: add chart dependencies for MariaDB and Redis

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -166,7 +166,7 @@ def install(ctx):
         "image": "owncloudci/alpine",
         "commands": [
             "export KUBECONFIG=kubeconfig-$${DRONE_BUILD_NUMBER}.yaml",
-            "helm install --values ci/ci-values.yaml --atomic --timeout 5m0s owncloud charts/owncloud/",
+            "helm install --dependency-update --values ci/ci-values.yaml --atomic --timeout 5m0s owncloud charts/owncloud/",
         ],
     }]
 

--- a/.drone.star
+++ b/.drone.star
@@ -76,6 +76,7 @@ def kubernetes(ctx, config):
                 "name": "helm-lint",
                 "image": "owncloudci/alpine",
                 "commands": [
+                    "helm dependency update charts/owncloud/",
                     "helm lint --strict charts/owncloud",
                 ],
             },

--- a/.drone.star
+++ b/.drone.star
@@ -222,6 +222,8 @@ def release(ctx):
                 "image": "quay.io/helmpack/chart-releaser",
                 "commands": [
                     "sed -i 's/version: 0.0.0-devel/version: %s/g' charts/owncloud/Chart.yaml" % (ctx.build.ref.replace("refs/tags/", "").replace("v", "") if ctx.build.event == "tag" else "0.0.0-devel"),
+                    "helm repo add bitnami https://charts.bitnami.com/bitnami",
+                    "helm repo update",
                     "cr package charts/owncloud/",
                 ],
             },

--- a/.drone.star
+++ b/.drone.star
@@ -220,6 +220,9 @@ def release(ctx):
             {
                 "name": "helm-repos",
                 "image": "owncloudci/alpine",
+                "environment": {
+                    "HELM_CONFIG_HOME": "/drone/src/.helm",
+                },
                 "commands": [
                     "helm repo add bitnami https://charts.bitnami.com/bitnami",
                     "helm repo update",
@@ -228,6 +231,9 @@ def release(ctx):
             {
                 "name": "helmpack-package",
                 "image": "quay.io/helmpack/chart-releaser",
+                "environment": {
+                    "HELM_CONFIG_HOME": "/drone/src/.helm",
+                },
                 "commands": [
                     "sed -i 's/version: 0.0.0-devel/version: %s/g' charts/owncloud/Chart.yaml" % (ctx.build.ref.replace("refs/tags/", "").replace("v", "") if ctx.build.event == "tag" else "0.0.0-devel"),
                     "cr package charts/owncloud/",

--- a/.drone.star
+++ b/.drone.star
@@ -218,12 +218,18 @@ def release(ctx):
                 ],
             },
             {
+                "name": "helm-repos",
+                "image": "owncloudci/alpine",
+                "commands": [
+                    "helm repo add bitnami https://charts.bitnami.com/bitnami",
+                    "helm repo update",
+                ],
+            },
+            {
                 "name": "helmpack-package",
                 "image": "quay.io/helmpack/chart-releaser",
                 "commands": [
                     "sed -i 's/version: 0.0.0-devel/version: %s/g' charts/owncloud/Chart.yaml" % (ctx.build.ref.replace("refs/tags/", "").replace("v", "") if ctx.build.event == "tag" else "0.0.0-devel"),
-                    "helm repo add bitnami https://charts.bitnami.com/bitnami",
-                    "helm repo update",
                     "cr package charts/owncloud/",
                 ],
             },

--- a/charts/owncloud/Chart.lock
+++ b/charts/owncloud/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.3.3
-digest: sha256:2cd414b3f3833c64e8cf7f37a40735e5ea47bb846b570da62476bee1a1953447
-generated: "2022-11-10T11:56:19.532007+01:00"
+digest: sha256:fcbf23bfe0ee10e50d729249a2c6ab4b90180c16be74c65626ca0eae58f292ef
+generated: "2022-11-11T18:30:00.785523+01:00"

--- a/charts/owncloud/Chart.lock
+++ b/charts/owncloud/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 17.3.7
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.3.3
+digest: sha256:69289c0136ec75f8ddb97d148973b41ff36a1452cb02049cb2ad6ce933319b19
+generated: "2022-11-02T18:09:01.624589+01:00"

--- a/charts/owncloud/Chart.lock
+++ b/charts/owncloud/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: redis
+- name: redis-cluster
   repository: https://charts.bitnami.com/bitnami
-  version: 17.3.7
+  version: 8.2.7
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.3.3
-digest: sha256:69289c0136ec75f8ddb97d148973b41ff36a1452cb02049cb2ad6ce933319b19
-generated: "2022-11-02T18:09:01.624589+01:00"
+digest: sha256:2cd414b3f3833c64e8cf7f37a40735e5ea47bb846b570da62476bee1a1953447
+generated: "2022-11-10T11:56:19.532007+01:00"

--- a/charts/owncloud/Chart.yaml
+++ b/charts/owncloud/Chart.yaml
@@ -21,10 +21,10 @@ sources:
   - https://github.com/owncloud-docker/server
   - https://github.com/owncloud/core
 dependencies:
-  - name: redis
-    version: 17.3.7
+  - name: redis-cluster
+    version: 8.2.7
     repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled
+    condition: redis-cluster.enabled
   - name: mariadb
     version: 11.3.3
     repository: https://charts.bitnami.com/bitnami

--- a/charts/owncloud/Chart.yaml
+++ b/charts/owncloud/Chart.yaml
@@ -20,3 +20,12 @@ sources:
   - https://github.com/owncloud-docker/helm-charts
   - https://github.com/owncloud-docker/server
   - https://github.com/owncloud/core
+dependencies:
+  - name: redis
+    version: 17.3.7
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+  - name: mariadb
+    version: 11.3.3
+    repository: https://charts.bitnami.com/bitnami
+    condition: mariadb.enabled

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -18,6 +18,11 @@ ownCloud Server Helm chart
 
 Kubernetes: `~1.21.0 || ~1.22.0 || ~1.23.0 || ~1.24.0 || ~1.25.0`
 
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | mariadb | 11.3.3 |
+| https://charts.bitnami.com/bitnami | redis | 17.3.7 |
+
 ## Usage
 
 ### Get Repo Info
@@ -72,6 +77,10 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | ingress.labels | object | `{}` | Labels for the ingress. |
 | ingress.tls | list | `[]` | Ingress TLS configuration. |
 | initResources | object | `{}` | Resources to apply to all init containers. |
+| mariadb.auth.database | string | `"owncloud"` |  |
+| mariadb.auth.password | string | `"owncloud"` |  |
+| mariadb.auth.username | string | `"owncloud"` |  |
+| mariadb.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Simple node selection constraint. |
 | owncloud.accesslogLocation | string | /dev/stdout | Location of the access log. |
@@ -254,20 +263,24 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.root | string | `"/mnt/data"` | Base data directory for ownCloud. |
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
-| persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
+| persistence.owncloud.accessMode | list | `["ReadWriteOnce"]` | Please set this to ReadWriteMany if NFS is used |
 | persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC. |
-| persistence.owncloud.nfs | object | `{}` |  |
+| persistence.owncloud.nfs.enabled | bool | `false` |  |
+| persistence.owncloud.nfs.patch | string | `""` |  |
+| persistence.owncloud.nfs.server | string | `""` |  |
 | persistence.owncloud.size | string | `"20Gi"` |  |
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |
 | podAnnotations | object | `{}` | Annotations to attach metadata to the Pod. |
 | podSecurityContext | object | `{}` | Security settings for the Pod. |
+| redis.auth.password | string | `""` |  |
+| redis.enabled | bool | `false` |  |
 | replicas | int | `1` | Number of replicas for each scalable service. Has no effect when `autoscaling.enabled` is set to `true`. |
 | resources | object | `{}` | Resources to apply to all services. |
 | securityContext | object | `{"readOnlyRootFilesystem":false}` | Security settings for the Container. |
 | securityContext.readOnlyRootFilesystem | bool | `false` | Mounts the container's root filesystem as read-only. Currently only `false` is supported by ownCloud 10. |
 | service.annotations | object | `{}` | Service annotations. |
 | service.port | int | `8080` |  |
-| service.type | string | `"LoadBalancer"` |  |
+| service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created or not. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is set to `true`, a name is generated using the fullname template. |

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -21,7 +21,7 @@ Kubernetes: `~1.21.0 || ~1.22.0 || ~1.23.0 || ~1.24.0 || ~1.25.0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb | 11.3.3 |
-| https://charts.bitnami.com/bitnami | redis | 17.3.7 |
+| https://charts.bitnami.com/bitnami | redis-cluster | 8.2.7 |
 
 ## Usage
 
@@ -270,8 +270,8 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |
 | podAnnotations | object | `{}` | Annotations to attach metadata to the Pod. |
 | podSecurityContext | object | `{}` | Security settings for the Pod. |
-| redis.auth.password | string | `""` |  |
-| redis.enabled | bool | `false` |  |
+| redis-cluster.auth.password | string | `""` |  |
+| redis-cluster.enabled | bool | `false` |  |
 | replicas | int | `1` | Number of replicas for each scalable service. Has no effect when `autoscaling.enabled` is set to `true`. |
 | resources | object | `{}` | Resources to apply to all services. |
 | securityContext | object | `{"readOnlyRootFilesystem":false}` | Security settings for the Container. |

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -263,11 +263,9 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.root | string | `"/mnt/data"` | Base data directory for ownCloud. |
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
-| persistence.owncloud.accessMode | list | `["ReadWriteOnce"]` | Please set this to ReadWriteMany if NFS is used |
+| persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
 | persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC. |
-| persistence.owncloud.nfs.enabled | bool | `false` |  |
-| persistence.owncloud.nfs.patch | string | `""` |  |
-| persistence.owncloud.nfs.server | string | `""` |  |
+| persistence.owncloud.nfs | object | `{}` |  |
 | persistence.owncloud.size | string | `"20Gi"` |  |
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |
 | podAnnotations | object | `{}` | Annotations to attach metadata to the Pod. |
@@ -280,7 +278,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | securityContext.readOnlyRootFilesystem | bool | `false` | Mounts the container's root filesystem as read-only. Currently only `false` is supported by ownCloud 10. |
 | service.annotations | object | `{}` | Service annotations. |
 | service.port | int | `8080` |  |
-| service.type | string | `"ClusterIP"` |  |
+| service.type | string | `"LoadBalancer"` |  |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created or not. |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and `create` is set to `true`, a name is generated using the fullname template. |

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -324,7 +324,7 @@ spec:
               value: {{ .Values.owncloud.proxyUserpwd | quote }}
             - name: OWNCLOUD_QUOTA_INCLUDE_EXTERNAL_STORAGE
               value: {{ .Values.owncloud.quotaIncludeExternalStorage | quote }}
-            {{- if or .Values.owncloud.redis.enabled .Values.redis.enabled }}
+            {{- if or .Values.owncloud.redis.enabled (index .Values "redis-cluster" "enabled") }}
             - name: OWNCLOUD_REDIS_ENABLED
               value: "true"
             - name: OWNCLOUD_REDIS_DB
@@ -335,16 +335,16 @@ spec:
             - name: OWNCLOUD_REDIS_ENABLED
               value: "false"
             {{- end }}
-            {{- if .Values.redis.enabled }}
+            {{- if (index .Values "redis-cluster" "enabled") }}
             - name: OWNCLOUD_REDIS_HOST
-              value: {{ .Release.Name }}-redis-master
+              value: ""
             {{- else }}
             - name: OWNCLOUD_REDIS_HOST
               value: {{ .Values.owncloud.redis.host | quote }}
             {{- end }}
-            {{- if .Values.redis.auth.password }}
+            {{- if (index .Values "redis-cluster" "password") }}
             - name: OWNCLOUD_REDIS_PASSWORD
-              value: {{ .Values.redis.auth.password | quote }}
+              value: {{ (index .Values "redis-cluster" "password") | quote }}
             {{- else }}
             - name: OWNCLOUD_REDIS_PASSWORD
               value: {{ .Values.owncloud.redis.password | quote }}
@@ -353,8 +353,13 @@ spec:
               value: {{ .Values.owncloud.redis.port | quote }}
             - name: OWNCLOUD_REDIS_READ_TIMEOUT
               value: {{ .Values.owncloud.redis.readTimeout | quote }}
+            {{- if (index .Values "redis-cluster" "enabled") }}
+            - name: OWNCLOUD_REDIS_SEEDS
+              value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}},{{end}}{{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}"
+            {{- else }}
             - name: OWNCLOUD_REDIS_SEEDS
               value: {{ .Values.owncloud.redis.seeds | quote }}
+            {{- end }}
             - name: OWNCLOUD_REDIS_SESSION_LOCKING_ENABLED
               value: {{ .Values.owncloud.redis.sessionLockingEnabled | quote }}
             - name: OWNCLOUD_REDIS_SESSION_LOCK_RETRIES
@@ -375,16 +380,22 @@ spec:
               value: {{ .Values.owncloud.session.lifetime | quote }}
             - name: OWNCLOUD_SESSION_FORCED_LOGOUT_TIMEOUT
               value: {{ .Values.owncloud.session.forcedLogoutTimeout | quote }}
-            {{- if and (or .Values.redis.enabled .Values.redis.enabled) (eq .Values.owncloud.session.saveHandler "files") }}
+            {{- if and (or .Values.owncloud.redis.enabled (index .Values "redis-cluster" "enabled")) (eq .Values.owncloud.session.saveHandler "files") }}
             - name: OWNCLOUD_SESSION_SAVE_HANDLER
-            # CHANGEME
-              value: {{ .Values.owncloud.session.saveHandler | quote }}
+              value: "rediscluster"
+            {{- if (index .Values "redis-cluster" "password") }}
+            - name: OWNCLOUD_SESSION_SAVE_PATH
+              value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}}&{{end}}seed[]={{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}?auth={{ (index .Values "redis-cluster" "password") }}"
+            {{- else }}
+            - name: OWNCLOUD_SESSION_SAVE_PATH
+              value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}}&{{end}}seed[]={{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}"
+            {{- end }}
             {{- else }}
             - name: OWNCLOUD_SESSION_SAVE_HANDLER
               value: {{ .Values.owncloud.session.saveHandler | quote }}
-            {{- end }}
             - name: OWNCLOUD_SESSION_SAVE_PATH
               value: {{ .Values.owncloud.session.savePath | quote }}
+            {{- end }}
             - name: OWNCLOUD_SHARE_FOLDER
               value: {{ .Values.owncloud.shareFolder | quote }}
             - name: OWNCLOUD_SHARING_FEDERATION_ALLOW_HTTP_FALLBACK

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -388,7 +388,7 @@ spec:
               value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}}&{{end}}seed[]={{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}?auth={{ (index .Values "redis-cluster" "password") }}"
             {{- else }}
             - name: OWNCLOUD_SESSION_SAVE_PATH
-              value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}}&{{end}}seed[]={{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}"
+              value: "{{ $count := (index .Values "redis-cluster" "cluster" "nodes") | int }}{{ range $i, $v := until $count }}{{if $i}}&{{end}}seed[]={{ include "common.names.fullname" (index $.Subcharts "redis-cluster") }}-{{ $i }}.{{ template "common.names.fullname" (index $.Subcharts "redis-cluster") }}-headless:{{ (index $.Values "redis-cluster" "redis" "containerPorts" "redis") }}{{ end }}&timeout=2&read_timeout=2&failover=error"
             {{- end }}
             {{- else }}
             - name: OWNCLOUD_SESSION_SAVE_HANDLER

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -101,20 +101,33 @@ spec:
               value: {{ .Values.owncloud.davEnableAsync | quote }}
             - name: OWNCLOUD_DB_FAIL
               value: {{ .Values.owncloud.db.fail | quote }}
+            - name: OWNCLOUD_DB_PREFIX
+              value: {{ .Values.owncloud.db.prefix | quote }}
+            - name: OWNCLOUD_DB_TIMEOUT
+              value: {{ .Values.owncloud.db.timeout | quote }}
+            {{- if .Values.mariadb.enabled }}
+            - name: OWNCLOUD_DB_HOST
+              value: {{ template "mariadb.primary.fullname" .Subcharts.mariadb }}
+            - name: OWNCLOUD_DB_NAME
+              value: {{ .Values.mariadb.auth.database | quote }}
+            - name: OWNCLOUD_DB_PASSWORD
+              value: {{ .Values.mariadb.auth.password | quote }}
+            - name: OWNCLOUD_DB_TYPE
+              value: "mysql"
+            - name: OWNCLOUD_DB_USERNAME
+              value: {{ .Values.mariadb.auth.username | quote }}
+            {{- else }}
             - name: OWNCLOUD_DB_HOST
               value: {{ .Values.owncloud.db.host | quote }}
             - name: OWNCLOUD_DB_NAME
               value: {{ .Values.owncloud.db.name | quote }}
             - name: OWNCLOUD_DB_PASSWORD
               value: {{ .Values.owncloud.db.password | quote }}
-            - name: OWNCLOUD_DB_PREFIX
-              value: {{ .Values.owncloud.db.prefix | quote }}
-            - name: OWNCLOUD_DB_TIMEOUT
-              value: {{ .Values.owncloud.db.timeout | quote }}
             - name: OWNCLOUD_DB_TYPE
               value: {{ .Values.owncloud.db.type | quote }}
             - name: OWNCLOUD_DB_USERNAME
               value: {{ .Values.owncloud.db.username | quote }}
+            {{- end }}
             - name: OWNCLOUD_DEBUG
               value: {{ .Values.owncloud.debug | quote }}
             - name: OWNCLOUD_DEFAULT_APP
@@ -311,15 +324,28 @@ spec:
               value: {{ .Values.owncloud.proxyUserpwd | quote }}
             - name: OWNCLOUD_QUOTA_INCLUDE_EXTERNAL_STORAGE
               value: {{ .Values.owncloud.quotaIncludeExternalStorage | quote }}
-            {{- if .Values.owncloud.redis.enabled }}
-            - name: OWNCLOUD_REDIS_DB
-              value: {{ .Values.owncloud.redis.db | quote }}
+            {{- if or .Values.owncloud.redis.enabled .Values.redis.enabled }}
             - name: OWNCLOUD_REDIS_ENABLED
               value: "true"
+            - name: OWNCLOUD_REDIS_DB
+              value: {{ .Values.owncloud.redis.db | quote }}
             - name: OWNCLOUD_REDIS_FAILOVER_MODE
               value: {{ .Values.owncloud.redis.failoverMode | quote }}
+            {{- else }}
+            - name: OWNCLOUD_REDIS_ENABLED
+              value: "false"
+            {{- end }}
+            {{- if .Values.redis.enabled }}
+            - name: OWNCLOUD_REDIS_HOST
+              value: {{ .Release.Name }}-redis-master
+            {{- else }}
             - name: OWNCLOUD_REDIS_HOST
               value: {{ .Values.owncloud.redis.host | quote }}
+            {{- end }}
+            {{- if .Values.redis.auth.password }}
+            - name: OWNCLOUD_REDIS_PASSWORD
+              value: {{ .Values.redis.auth.password | quote }}
+            {{- else }}
             - name: OWNCLOUD_REDIS_PASSWORD
               value: {{ .Values.owncloud.redis.password | quote }}
             {{- end }}
@@ -349,8 +375,14 @@ spec:
               value: {{ .Values.owncloud.session.lifetime | quote }}
             - name: OWNCLOUD_SESSION_FORCED_LOGOUT_TIMEOUT
               value: {{ .Values.owncloud.session.forcedLogoutTimeout | quote }}
+            {{- if and (or .Values.redis.enabled .Values.redis.enabled) (eq .Values.owncloud.session.saveHandler "files") }}
+            - name: OWNCLOUD_SESSION_SAVE_HANDLER
+            # CHANGEME
+              value: {{ .Values.owncloud.session.saveHandler | quote }}
+            {{- else }}
             - name: OWNCLOUD_SESSION_SAVE_HANDLER
               value: {{ .Values.owncloud.session.saveHandler | quote }}
+            {{- end }}
             - name: OWNCLOUD_SESSION_SAVE_PATH
               value: {{ .Values.owncloud.session.savePath | quote }}
             - name: OWNCLOUD_SHARE_FOLDER

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -496,3 +496,18 @@ affinity: {}
 # One or more taints need to be applied to a node to instruct this node to not accept any pods
 # that do not tolerate the taints.
 tolerations: []
+
+## MariaDB chart configuration, see https://artifacthub.io/packages/helm/bitnami/mariadb
+mariadb:
+  enabled: false
+
+  auth:
+    database: owncloud
+    username: owncloud
+    password: owncloud
+
+## Redis chart configuration, see https://artifacthub.io/packages/helm/bitnami/redis
+redis:
+  enabled: false
+  auth:
+    password: ""

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -507,7 +507,7 @@ mariadb:
     password: owncloud
 
 ## Redis chart configuration, see https://artifacthub.io/packages/helm/bitnami/redis
-redis:
+redis-cluster:
   enabled: false
   auth:
     password: ""


### PR DESCRIPTION
This PR adds chart dependencies for MariaDB and Redis including configuration in this chart's values.yaml.