### PR TITLE
feat: add support for Kubernetes prerelease versions

### DIFF
--- a/charts/owncloud/Chart.yaml
+++ b/charts/owncloud/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
     email: devops@owncloud.com
     url: https://owncloud.com
 type: application
-kubeVersion: "~1.21.0 || ~1.22.0 || ~1.23.0 || ~1.24.0 || ~1.25.0" # if this changes, also kubernetesVersions in .drone.star needs to be changed
+kubeVersion: "~1.21.0-0 || ~1.22.0-0 || ~1.23.0-0 || ~1.24.0-0 || ~1.25.0-0" # if this changes, also kubernetesVersions in .drone.star needs to be changed
 sources:
   - https://github.com/owncloud-docker/helm-charts
   - https://github.com/owncloud-docker/server

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -16,7 +16,7 @@ ownCloud Server Helm chart
 
 ## Requirements
 
-Kubernetes: `~1.21.0 || ~1.22.0 || ~1.23.0 || ~1.24.0 || ~1.25.0`
+Kubernetes: `~1.21.0-0 || ~1.22.0-0 || ~1.23.0-0 || ~1.24.0-0 || ~1.25.0-0`
 
 ## Usage
 


### PR DESCRIPTION
According to pages like https://github.com/goharbor/harbor-operator/issues/453 the versioning in `kubeVersion` needs to add `-0` to catch also release numbers like `v1.24.0-2368+b62823b40c2cb1-dirty`