### PR TITLE
feat: add uid check for chown in initContainer

### DIFF
--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -33,14 +33,24 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: "init-{{ .Chart.Name }}"
+        - name: "init-{{ .Chart.Name }}-mkdir"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}; {{ if not .Values.skipChown -}} chown -R www-data:www-data {{ .Values.owncloud.volume.root }} {{- end }}"]
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}"]
           volumeMounts:
             - name: owncloud-data
               mountPath: {{ .Values.owncloud.volume.root }}
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
+        {{- if not .Values.skipChown }}
+        - name: "init-{{ .Chart.Name }}-chown"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ['sh', '-c', "chown -R www-data:www-data {{ .Values.owncloud.volume.root }}"]
+          volumeMounts:
+            - name: owncloud-data
+              mountPath: {{ .Values.owncloud.volume.root }}
+          resources:
+            {{- toYaml .Values.initResources | nindent 12 }}
+        {{- end }}
 
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       initContainers:
         - name: "init-{{ .Chart.Name }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}; if [ \"0\" -eq \"$(id -u)\" ]; then chown -R www-data:www-data {{ .Values.owncloud.volume.root }}; fi"]
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}; {{ if not .Values.skipChown -}} chown -R www-data:www-data {{ .Values.owncloud.volume.root }} {{- end }}"]
           volumeMounts:
             - name: owncloud-data
               mountPath: {{ .Values.owncloud.volume.root }}

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       initContainers:
         - name: "init-{{ .Chart.Name }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}; chown -R www-data:www-data {{ .Values.owncloud.volume.root }}"]
+          command: ['sh', '-c', "mkdir -p {{ .Values.owncloud.volume.apps }} {{ .Values.owncloud.volume.config }} {{ .Values.owncloud.volume.files }} {{ .Values.owncloud.volume.sessions }}; if [ \"0\" -eq \"$(id -u)\" ]; then chown -R www-data:www-data {{ .Values.owncloud.volume.root }}; fi"]
           volumeMounts:
             - name: owncloud-data
               mountPath: {{ .Values.owncloud.volume.root }}


### PR DESCRIPTION
If the initContainer is started in an environment which is rootless (e.g. OpenShift) the `chown` command will fail. This PR adds a check for the user id before executing `chown` to avoid this.