### PR TITLE
Fix: Service name does not match ingress value

### DIFF
--- a/charts/owncloud/templates/service.yaml
+++ b/charts/owncloud/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: owncloud
+  name: {{ template "owncloud.fullname" . }}
   labels:
     {{- include "owncloud.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}


### PR DESCRIPTION
The service name is fixed to owncloud and it have to match the ingress value to be found. The value in the ingress class is "{{ template "owncloud.fullname" . }}" which is better to be able to run multiple instance of owncloud in a single namespace.