### PR TITLE
ci: fix the helm index path

### DIFF
--- a/cr.yaml
+++ b/cr.yaml
@@ -3,6 +3,6 @@ owner: owncloud-docker
 git-repo: helm-charts
 pages-branch: gh_pages
 package-path: dist/files/
-index-path: dist/docs/index.yaml
+index-path: dist/index.yaml
 release-name-template: "v{{ .Version }}"
 release-notes-file: CHANGELOG.md


### PR DESCRIPTION
The Helm repo is no longer updated when a release is created, the path is no longer correct : https://owncloud-docker.github.io/helm-charts/index.yaml

The bad repo : https://owncloud-docker.github.io/helm-charts/docs/index.yaml