### PR TITLE
fix: initContainer execution with skipChown enabled

### DIFF
--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               mountPath: {{ .Values.owncloud.volume.root }}
           resources:
             {{- toYaml .Values.initResources | nindent 12 }}
-        {{- if not .Values.skipChown }}
+        {{- if not .Values.owncloud.skipChown }}
         - name: "init-{{ .Chart.Name }}-chown"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: ['sh', '-c', "chown -R www-data:www-data {{ .Values.owncloud.volume.root }}"]

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -378,7 +378,7 @@ spec:
             - name: OWNCLOUD_SKIP_CHMOD
               value: {{ .Values.owncloud.skipChmod | quote }}
             - name: OWNCLOUD_SKIP_CHOWN
-              value: {{ .Values.owncloud.skipChown | quote }}
+              value: "true"
             - name: OWNCLOUD_SMB_LOGGING_ENABLE
               value: {{ .Values.owncloud.smbLoggingEnable | quote }}
             - name: OWNCLOUD_SQLITE_JOURNAL_MODE

--- a/ci/ci-values.yaml
+++ b/ci/ci-values.yaml
@@ -6,6 +6,9 @@ service:
   type: NodePort
   port: 8080
 
+owncloud:
+  skipChown: false
+
 initResources:
   limits:
     cpu: 100m


### PR DESCRIPTION
Currently the initContainer for Chown is executed even if it should be skipped as the wrong value is referenced. This PR fixes this issue.