### PR TITLE
fix: add PV selector for PVC

### DIFF
--- a/charts/owncloud/templates/pvc.yaml
+++ b/charts/owncloud/templates/pvc.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ include "owncloud.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
 spec:
   accessModes:
     {{- toYaml .Values.persistence.owncloud.accessMode | nindent 4 }}
@@ -24,6 +26,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.persistence.owncloud.nfs.enabled }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "owncloud.fullname" . }}
+{{- end }}
   accessModes:
     {{- toYaml .Values.persistence.owncloud.accessMode | nindent 4 }}
   resources:


### PR DESCRIPTION
Add PV selector for PVC when `persistence.owncloud.nfs.enabled: true` otherwise nfs PV is created but not used and another PV is created on `local-path`