### PR TITLE
chore: bump k3d api version

### DIFF
--- a/ci/k3d-drone.yaml
+++ b/ci/k3d-drone.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:

--- a/ci/k3d-drone.yaml
+++ b/ci/k3d-drone.yaml
@@ -1,5 +1,4 @@
----
-apiVersion: k3d.io/v1alpha4
+apiVersion: k3d.io/v1alpha5
 kind: Simple
 metadata:
   name: drone


### PR DESCRIPTION
Meanwhile there are newer version of the k3s image and the k3d apiVersion available. This PR increased the version to match.