### PR TITLE
feat: added extraVolumes and extraVolumeMounts to owncloud deployment

### DIFF
--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -120,6 +120,8 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.entrypointInitialized | string | `""` | Enable or disable loading of files from `/etc/entrypoint.d`. It is recommended to keep the default. |
 | owncloud.errorlogLocation | string | `"/dev/stderr"` | Output location for the Apache error log. |
 | owncloud.excludedDirectories | string | `""` | Define excluded directories (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-excluded-directories)). |
+| owncloud.extraVolumeMounts | list | `[]` | Additional volume mounts for the ownCloud container and cronjob. |
+| owncloud.extraVolumes | list | `[]` | Additional volumes for the ownCloud container and cronjob. |
 | owncloud.filelockingEnabled | string | `"true"` | Enable transactional file locking (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#enable-transactional-file-locking)). |
 | owncloud.filelockingTtl | string | `""` | Define the TTL for file locking (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-ttl-for-file-locking)). |
 | owncloud.filesExternalAllowNewLocal | string | `""` | Enable or disable the files_external local mount option (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#enable-or-disable-the-files_external-local-mount-option)). |

--- a/charts/owncloud/templates/cronjob.yaml
+++ b/charts/owncloud/templates/cronjob.yaml
@@ -44,6 +44,9 @@ spec:
               - name: config-volume
                 mountPath: {{ .Values.owncloud.volume.config }}/configmap.config.php
                 subPath: configmap.config.php
+              {{- with .Values.owncloud.extraVolumeMounts }}
+                {{- toYaml . | nindent 14 }}
+              {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}
@@ -65,4 +68,7 @@ spec:
             - name: config-volume
               secret:
                 secretName: owncloud-config
+            {{- with .Values.owncloud.extraVolumes }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
 {{- end -}}

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -94,6 +94,9 @@ spec:
             - name: config-volume
               mountPath: {{ .Values.owncloud.volume.config }}/configmap.config.php
               subPath: configmap.config.php
+            {{- with .Values.owncloud.extraVolumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -115,3 +118,6 @@ spec:
         - name: config-volume
           secret:
             secretName: owncloud-config
+        {{- with .Values.owncloud.extraVolumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -115,6 +115,10 @@ owncloud:
   errorlogLocation: "/dev/stderr"
   # -- Define excluded directories (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-excluded-directories)).
   excludedDirectories: ""
+  # -- Additional volumes for the ownCloud container and cronjob.
+  extraVolumes: []
+  # -- Additional volume mounts for the ownCloud container and cronjob.
+  extraVolumeMounts: []
   # -- Enable transactional file locking (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#enable-transactional-file-locking)).
   filelockingEnabled: "true"
   # -- Define the TTL for file locking (see [documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/server/config_sample_php_parameters.html#define-the-ttl-for-file-locking)).


### PR DESCRIPTION
This PR helps to address #66 by adding support for extra volume mounts. This allows additional config maps or volumes to be mounted in order to add or extend behavior. In the case of #66, this can be used to mount in a config map for use with `OWNCLOUD_PRE_CRONJOB_PATH` to run additional background behavior.

## Tests?

Manually tested by modifying the default values.yaml and rendering locally and inspecting both deployment and cronjob.

```
$ helm template example ./charts/owncloud -f charts/owncloud/values.yaml
...
          volumeMounts:
            - name: owncloud-data
              mountPath: /mnt/data
            - name: config-volume
              mountPath: /mnt/data/config/configmap.config.php
              subPath: configmap.config.php
            - mountPath: /super-secret
              name: extra-volume
      volumes:
        - name: owncloud-data
          persistentVolumeClaim:
            claimName: example-owncloud
        - name: config-volume
          secret:
            secretName: owncloud-config
        - name: extra-volume
          secret:
            secretName: super-secret-volume
...
```

