### PR TITLE
feat: Adding `persistence.existingClaim` value to forgo the creation of a PVC in favour of using one with the name in this value.

### DIFF
--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -255,6 +255,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.root | string | `"/mnt/data"` | Base data directory for ownCloud. |
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
+| persistence.existingClaim | string | `~` | Disables creation of PVC in favour of using existing PVC by name defined in this value. |
 | persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
 | persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC. |
 | persistence.owncloud.nfs | object | `{}` |  |

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -255,9 +255,9 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 | owncloud.volume.root | string | `"/mnt/data"` | Base data directory for ownCloud. |
 | owncloud.volume.sessions | string | `{{ .Values.owncloud.volume.root }}/sessions` | Base directory to store session files. Only used if `OWNCLOUD_SESSION_SAVE_HANDLER=file`. |
 | persistence.enabled | bool | `true` | Enables persistence. |
-| persistence.existingClaim | string | `~` | Disables creation of PVC in favour of using existing PVC by name defined in this value. |
 | persistence.owncloud.accessMode[0] | string | `"ReadWriteOnce"` |  |
 | persistence.owncloud.annotations | object | `{"helm.sh/resource-policy":"keep"}` | Set annotations on the owncloud PVC. |
+| persistence.owncloud.existingClaim | string | `nil` | Disables creation of PVC in favour of using existing PVC by name defined in this value. |
 | persistence.owncloud.nfs | object | `{}` |  |
 | persistence.owncloud.size | string | `"20Gi"` |  |
 | persistence.owncloud.storageClassName | string | `""` | owncloud data Persistent Volume Storage Class. If defined, `storageClassName` of the PVC is set to the value defined here. If set to "-", `storageClassName`of the PVC is set to `""`, which disables dynamic provisioning. If undefined (the default) or set to null, no `storageClassName` spec is set, choosing the default provisioner. |

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -113,8 +113,8 @@ spec:
         - name: owncloud-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-          {{- if .Values.persistence.existingClaim }}
-            claimName: {{ .Values.persistence.existingClaim }}
+          {{- if .Values.persistence.owncloud.existingClaim }}
+            claimName: {{ .Values.persistence.owncloud.existingClaim }}
           {{- else }}
             claimName: {{ include "owncloud.fullname" . }}
           {{- end }}

--- a/charts/owncloud/templates/deployment.yaml
+++ b/charts/owncloud/templates/deployment.yaml
@@ -113,7 +113,11 @@ spec:
         - name: owncloud-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
+          {{- if .Values.persistence.existingClaim }}
+            claimName: {{ .Values.persistence.existingClaim }}
+          {{- else }}
             claimName: {{ include "owncloud.fullname" . }}
+          {{- end }}
           {{- end }}
         - name: config-volume
           secret:

--- a/charts/owncloud/templates/pvc.yaml
+++ b/charts/owncloud/templates/pvc.yaml
@@ -14,6 +14,7 @@ spec:
     path: {{ .Values.persistence.owncloud.nfs.path }}
 {{end}}
 {{- if .Values.persistence.enabled -}}
+{{- if not .Values.persistence.existingClaim -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -36,4 +37,5 @@ spec:
   storageClassName: {{ .Values.persistence.owncloud.storageClassName }}
   {{- end }}
   {{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/owncloud/templates/pvc.yaml
+++ b/charts/owncloud/templates/pvc.yaml
@@ -14,7 +14,7 @@ spec:
     path: {{ .Values.persistence.owncloud.nfs.path }}
 {{end}}
 {{- if .Values.persistence.enabled -}}
-{{- if not .Values.persistence.existingClaim -}}
+{{- if not .Values.persistence.owncloud.existingClaim -}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -405,7 +405,7 @@ persistence:
   # -- Enables persistence.
   enabled: true
   owncloud:
-    # existingClaim will, if set, forgo the creation of a PVC in favour of mounting an existing one with this name.
+    # -- Disables creation of PVC in favour of using existing PVC by name defined in this value.
     existingClaim: ~
     accessMode:
       - ReadWriteOnce

--- a/charts/owncloud/values.yaml
+++ b/charts/owncloud/values.yaml
@@ -405,6 +405,8 @@ persistence:
   # -- Enables persistence.
   enabled: true
   owncloud:
+    # existingClaim will, if set, forgo the creation of a PVC in favour of mounting an existing one with this name.
+    existingClaim: ~
     accessMode:
       - ReadWriteOnce
     size: 20Gi


### PR DESCRIPTION
Trying to upgrade our existing owncloud Helm release is failing with the error message:

```Error: UPGRADE FAILED: failed to replace object: PersistentVolumeClaim "owncloud-etl" is invalid: spec: Forbidden: spec is immutable after creation except resources.requests for bound claims
  core.PersistentVolumeClaimSpec{
        AccessModes:      {"ReadWriteMany"},
        Selector:         nil,
        Resources:        {Requests: {s"storage": {i: {...}, Format: "BinarySI"}}},
-       VolumeName:       "pvc-d3862995-1f6d-47e4-bdcd-ee722da47087",
+       VolumeName:       "",
        StorageClassName: &"kadalu.etl-bi-owncloud-storage",
        VolumeMode:       &"Filesystem",
        ... // 2 identical fields
  }
```

The issue seems to be that Helm will try to patch the PVC it already created in the original install, not passing it `volumeMode` and `volumeName` fields, whereas the existing PVC object has these set somehow. To bypass this issue, we're implementing a `persistence.existingClaim` field that, when set, skips the creation of the PVC entirely and mounts the specific PVC by name to the deployment's spec.

This involves a bit of a "hack", in that a user would need to run the initial install without setting `persistence.existingClaim` (it defaults to `~`), but then set it to the name of the PVC that is created for subsequent `helm upgrade...` instructions. Open to better alternative solutions, but this works for our purposes.