### PR TITLE
Update pvc.yaml to include the storageClassName to the PersistentVolume

### DIFF
--- a/charts/owncloud/templates/pvc.yaml
+++ b/charts/owncloud/templates/pvc.yaml
@@ -12,6 +12,13 @@ spec:
   nfs:
     server: {{ .Values.persistence.owncloud.nfs.server }}
     path: {{ .Values.persistence.owncloud.nfs.path }}
+  {{- if .Values.persistence.owncloud.storageClassName }}
+  {{- if (eq "-" .Values.persistence.owncloud.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.persistence.owncloud.storageClassName }}
+  {{- end }}
+  {{- end }}
 {{end}}
 {{- if .Values.persistence.enabled -}}
 ---


### PR DESCRIPTION
I believe you will need to also add the storageClassName to the persistent volume in order for the PVC to see the PV