### PR TITLE
ci: use reusable lint-editorconfig workflow

### DIFF
--- a/.github/workflows/lint-editorconfig.yml
+++ b/.github/workflows/lint-editorconfig.yml
@@ -1,0 +1,11 @@
+name: Lint EditorConfig
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    uses: owncloud-docker/ubuntu/.github/workflows/lint-editorconfig.yml@master


### PR DESCRIPTION
## Summary
- Adds editorconfig linting via the reusable `owncloud-docker/ubuntu/.github/workflows/lint-editorconfig.yml` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)