### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic"

### DIFF
--- a/charts/owncloud/Chart.yaml
+++ b/charts/owncloud/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v2
 name: owncloud
 version: 0.0.0-devel
-description: ownCloud Server Helm chart
+description: ownCloud Classic Helm chart
 # renovate: datasource=docker depName=owncloud/server
 appVersion: 10.16.2
 home: https://owncloud.com/

--- a/charts/owncloud/README.md
+++ b/charts/owncloud/README.md
@@ -4,7 +4,7 @@
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat)
 ![AppVersion: 10.15.1](https://img.shields.io/badge/AppVersion-10.15.1-informational?style=flat)
 
-ownCloud Server Helm chart
+ownCloud Classic Helm chart
 
 **Homepage:** <https://owncloud.com/>
 


### PR DESCRIPTION
Renames the chart description to **ownCloud Classic Helm chart** in both the `Chart.yaml` source-of-truth and the generated chart `README.md`, keeping them consistent.

**Scope:** prose only. The "supported by ownCloud 10" read-only-filesystem note is an instance/version constraint and is left unchanged.

Part of the cross-repo rebrand campaign tracked in owncloud/docs#5111 (owncloud-docker org).